### PR TITLE
Fix threaded buffering status

### DIFF
--- a/lib/buffering_logger/buffer.rb
+++ b/lib/buffering_logger/buffer.rb
@@ -11,15 +11,15 @@ class BufferingLogger::Buffer
   # buffers during the block and then flushes.
   # returns the value of the block.
   def buffered(transform: nil)
-    @buffering = true
+    self.buffering = true
     yield
   ensure
-    @buffering = false
+    self.buffering = false
     flush(transform: transform)
   end
 
   def write(msg)
-    if @buffering
+    if buffering
       buffer.write(msg)
     else
       logdev_write(msg)
@@ -60,6 +60,18 @@ class BufferingLogger::Buffer
 
   def buffer_id
     "buffering_logger_#{object_id}_buffer"
+  end
+
+  def buffering
+    Thread.current[buffering_id]
+  end
+
+  def buffering=(val)
+    Thread.current[buffering_id] = val
+  end
+
+  def buffering_id
+    "buffering_logger_#{object_id}_is_buffering"
   end
 
 end


### PR DESCRIPTION
Previously the `buffering` status was being set as an instance variable, which
meant that even though threaded buffers were separate, threaded usage could
change the `buffering` status for a different thread.

For threaded web servers this meant that logs were not lost but they also were
not buffered properly.

For manual threads inside of a single request (e.g. using `Thread.new`) this
could cause logs to be lost.